### PR TITLE
Release/0.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 0 - Create from Python 3.10-alpine3.15 image
 # FROM python:3.12.0b2-slim-bookworm as stage0
-FROM python:3.12.0b2-slim-bookworm 
+FROM python:3.12-slim-bullseye 
 RUN apt update && apt install -y python3-venv
 
 # Stage 1 - Copy Generate code

--- a/license_returner/License.py
+++ b/license_returner/License.py
@@ -48,6 +48,14 @@ class License:
         self.dataset = dataset
         self.ptype = "ql" if processing_type == "quicklook" else "r"
         self.logger = logger
+        self.idl_license_dict = {
+            "floating_idl_located": "None",
+            "floating_idl_located_number": 0,
+            "dataset_quicklook_idl_located": "None",
+            "dataset_quicklook_idl_located_number": 0,
+            "dataset_refined_idl_located": "None",
+            "dataset_refined_idl_located_number": 0
+        }
         
     def return_licenses(self):
         """Returns IDL licenses that were in use by the current workflow execution.
@@ -70,6 +78,8 @@ class License:
                 floating_lic = None
                 self.logger.info("Quicklook licenses exist and floating license(s) belongs to quicklook operations.")
                 self.logger.info(f"Not modifying floating license(s).")
+                self.idl_license_dict["floating_idl_located"] = "None"
+                self.idl_license_dict["floating_idl_located_number"] = 0
         
         try:
             # Get number of dataset licenses that were used in the workflow
@@ -122,10 +132,16 @@ class License:
             parameter = ssm.get_parameter(Name=parameter_name)["Parameter"]["Value"]
             if "floating" in parameter_name:
                 ltype = "floating"
+                self.idl_license_dict["floating_idl_located"] = parameter_name
+                self.idl_license_dict["floating_idl_located_number"] = parameter
             elif "ql" in parameter_name:
                 ltype = "quicklook dataset"
+                self.idl_license_dict["dataset_quicklook_idl_located"] = parameter_name
+                self.idl_license_dict["dataset_quicklook_idl_located_number"] = parameter
             else:
                 ltype = "refined dataset"
+                self.idl_license_dict["dataset_refined_idl_located"] = parameter_name
+                self.idl_license_dict["dataset_refined_idl_located_number"] = parameter
             self.logger.info(f"Located {ltype} {parameter_name}: {parameter} reserved licenses.")
         except botocore.exceptions.ClientError as e:
             if "(ParameterNotFound)" in str(e) :

--- a/license_returner/License.py
+++ b/license_returner/License.py
@@ -190,7 +190,7 @@ class License:
                 self.logger.info(f"Wrote {dataset_lic} license(s) to {self.prefix}-idl-{self.dataset} parameter.")
             if floating_lic:
                 current_floating = ssm.get_parameter(Name=f"{self.prefix}-idl-floating")["Parameter"]["Value"]
-                self.logger.info(f"Current floating pool: {current}.")
+                self.logger.info(f"Current floating pool: {current_floating}.")
                 floating_total = int(floating_lic) + int(current_floating)
                 response = ssm.put_parameter(
                     Name=f"{self.prefix}-idl-floating",

--- a/license_returner/License.py
+++ b/license_returner/License.py
@@ -120,7 +120,8 @@ class License:
         
         try:
             parameter = ssm.get_parameter(Name=parameter_name)["Parameter"]["Value"]
-            self.logger.info(f"Located {parameter_name}: {parameter} reserved licenses.")
+            ltype = "floating" if "floating" in parameter_name else "dataset"
+            self.logger.info(f"Located {ltype} {parameter_name}: {parameter} reserved licenses.")
         except botocore.exceptions.ClientError as e:
             if "(ParameterNotFound)" in str(e) :
                 parameter = None

--- a/license_returner/License.py
+++ b/license_returner/License.py
@@ -120,7 +120,12 @@ class License:
         
         try:
             parameter = ssm.get_parameter(Name=parameter_name)["Parameter"]["Value"]
-            ltype = "floating" if "floating" in parameter_name else "dataset"
+            if "floating" in parameter_name:
+                ltype = "floating"
+            elif "ql" in parameter_name:
+                ltype = "quicklook dataset"
+            else:
+                ltype = "refined dataset"
             self.logger.info(f"Located {ltype} {parameter_name}: {parameter} reserved licenses.")
         except botocore.exceptions.ClientError as e:
             if "(ParameterNotFound)" in str(e) :

--- a/license_returner/License.py
+++ b/license_returner/License.py
@@ -175,7 +175,7 @@ class License:
                     Tier="Standard",
                     Overwrite=True
                 )
-                self.logger.info(f"Wrote {floating_lic} license(s)to {self.prefix}-idl-floating parameter.")
+                self.logger.info(f"Wrote {floating_lic} license(s) to {self.prefix}-idl-floating parameter.")
         except botocore.exceptions.ClientError as e:
             self.logger.info(f"Could not return IDL licenses to {self.prefix}-idl-{self.dataset} and {self.prefix}-idl-floating...")
             self.logger.error(e)

--- a/license_returner/License.py
+++ b/license_returner/License.py
@@ -107,7 +107,8 @@ class License:
                 self.hold_license(ssm, "False")
             
         except botocore.exceptions.ClientError as e:
-            self.logger.error(f"Error encountered: {e}")
+            ssm = boto3.client("ssm", region_name="us-west-2")
+            self.hold_license(ssm, "False")
             self.logger.info("System exit.")
             exit(1)
             
@@ -125,6 +126,7 @@ class License:
                 parameter = None
                 self.logger.info(f"Could not locate {parameter_name}.")
             else:
+                self.logger.info(f"Erorr encountered with parameter: {parameter_name}.")
                 self.logger.error(f"Error encountered: {e}")
                 self.logger.info("System exit.")
                 exit(1)
@@ -144,7 +146,8 @@ class License:
             )
             self.logger.info(f"{hold_action.capitalize()}d hold on IDL licenses.")
         except botocore.exceptions.ClientError as e:
-            self.logger.error(f"Could not {hold_action} a hold on licenses...")
+            self.logger.info(f"Could not {hold_action} a hold on licenses...")
+            self.logger.error(e)
             raise e
         
     def write_licenses(self, ssm, dataset_lic, floating_lic):
@@ -174,5 +177,6 @@ class License:
                 )
                 self.logger.info(f"Wrote {floating_lic} license(s)to {self.prefix}-idl-floating parameter.")
         except botocore.exceptions.ClientError as e:
-            self.logger.error(f"Could not return IDL licenses to {self.prefix}-idl-{self.dataset} and {self.prefix}-idl-floating...")
+            self.logger.info(f"Could not return IDL licenses to {self.prefix}-idl-{self.dataset} and {self.prefix}-idl-floating...")
+            self.logger.error(e)
             raise e

--- a/license_returner/License.py
+++ b/license_returner/License.py
@@ -178,6 +178,7 @@ class License:
         try:
             if dataset_lic:
                 current = ssm.get_parameter(Name=f"{self.prefix}-idl-{self.dataset}")["Parameter"]["Value"]
+                self.logger.info(f"Current dataset pool: {current}.")
                 total = int(dataset_lic) + int(current)
                 response = ssm.put_parameter(
                     Name=f"{self.prefix}-idl-{self.dataset}",
@@ -189,6 +190,7 @@ class License:
                 self.logger.info(f"Wrote {dataset_lic} license(s) to {self.prefix}-idl-{self.dataset} parameter.")
             if floating_lic:
                 current_floating = ssm.get_parameter(Name=f"{self.prefix}-idl-floating")["Parameter"]["Value"]
+                self.logger.info(f"Current floating pool: {current}.")
                 floating_total = int(floating_lic) + int(current_floating)
                 response = ssm.put_parameter(
                     Name=f"{self.prefix}-idl-floating",

--- a/license_returner/return_license.py
+++ b/license_returner/return_license.py
@@ -40,10 +40,14 @@ def run_license_returner():
     logger.info(f"Unique identifier: {unique_id}")
     logger.info(f"Dataset: {ds}")
     logger.info(f"Processing type: {processing_type.upper()}")
+    execution_data = f"job_id {os.environ.get('AWS_BATCH_JOB_ID')} - unique_id: {unique_id} - dataset: {ds} - processing_type: {processing_type.upper()}"
     
     # Return licenses
     license = License(unique_id, prefix, dataset, processing_type, logger)
     license.return_licenses()
+    
+    # Print final log message
+    print_final_log(logger, execution_data, license.idl_license_dict)
     
     end = datetime.datetime.now()
     logger.info(f"Total execution time: {end - start}")
@@ -72,6 +76,17 @@ def get_logger():
 
     # Return logger
     return logger
+
+def print_final_log(logger, execution_data, idl_license_dict):
+    """Print final log message."""
+    
+    # Organize file data into a string
+    final_log_message = execution_data
+    for key,value in idl_license_dict.items():
+        final_log_message += f" - {key}: {value}"
+    
+    # Print final log message and remove temp log file
+    logger.info(final_log_message)
     
 if __name__ == "__main__":
     run_license_returner()

--- a/license_returner/return_license.py
+++ b/license_returner/return_license.py
@@ -40,7 +40,7 @@ def run_license_returner():
     logger.info(f"Unique identifier: {unique_id}")
     logger.info(f"Dataset: {ds}")
     logger.info(f"Processing type: {processing_type.upper()}")
-    execution_data = f"job_id {os.environ.get('AWS_BATCH_JOB_ID')} - unique_id: {unique_id} - dataset: {ds} - processing_type: {processing_type.upper()}"
+    execution_data = f"unique_id: {unique_id} - dataset: {ds} - processing_type: {processing_type.upper()} - job_id {os.environ.get('AWS_BATCH_JOB_ID')}"
     
     # Return licenses
     license = License(unique_id, prefix, dataset, processing_type, logger)

--- a/license_returner/return_license.py
+++ b/license_returner/return_license.py
@@ -12,6 +12,7 @@ Args:
 # Standard imports 
 import datetime
 import logging
+import os
 import sys
 
 # Local imports
@@ -27,8 +28,20 @@ def run_license_returner():
     dataset = sys.argv[3]
     processing_type = sys.argv[4]
     
-    # Return licenses
+    # Log current execution state
     logger = get_logger()
+    if dataset == "aqua":
+        ds = "MODIS Aqua"
+    elif dataset == "terra":
+        ds = "MODIS Terra"
+    else:
+        ds = "VIIRS"
+    logger.info(f"Job identifier: {os.environ.get('AWS_BATCH_JOB_ID')}")
+    logger.info(f"Unique identifier: {unique_id}")
+    logger.info(f"Dataset: {ds}")
+    logger.info(f"Processing type: {processing_type.upper()}")
+    
+    # Return licenses
     license = License(unique_id, prefix, dataset, processing_type, logger)
     license.return_licenses()
     

--- a/license_returner/return_license.py
+++ b/license_returner/return_license.py
@@ -13,7 +13,9 @@ Args:
 import datetime
 import logging
 import os
+import random
 import sys
+import time
 
 # Local imports
 from License import License
@@ -41,6 +43,12 @@ def run_license_returner():
     logger.info(f"Dataset: {ds}")
     logger.info(f"Processing type: {processing_type.upper()}")
     execution_data = f"unique_id: {unique_id} - dataset: {ds} - processing_type: {processing_type.upper()} - job_id {os.environ.get('AWS_BATCH_JOB_ID')}"
+    
+    # Sleep random n seconds to deal with concurrency
+    random.seed(a=os.environ.get('AWS_BATCH_JOB_ID'), version=2)
+    s = random.randint(1,10)
+    logger.info(f"Sleeping {s} seconds...")
+    time.sleep(s)
     
     # Return licenses
     license = License(unique_id, prefix, dataset, processing_type, logger)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-boto3==1.26.73
-botocore==1.29.73
+boto3==1.28.63
+botocore==1.31.63
 jmespath==1.0.1
 python-dateutil==2.8.2
-s3transfer==0.6.0
+s3transfer==0.7.0
 six==1.16.0
-urllib3==1.26.14
+urllib3==1.26.17

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -5,9 +5,9 @@ variable "app_name" {
 }
 
 variable "app_version" {
-  type        = number
+  type        = string
   description = "The application version number"
-  default     = 0.1
+  default     = "0.1.1"
 }
 
 variable "aws_region" {


### PR DESCRIPTION
### Description

Release of Cloud-Generate version 0.1.1.

Scope:

- Update logs for Cloud Metrics.
- Fix SNYK identified vulnerabilities.
- [Allow for concurrent executions.](https://wiki.jpl.nasa.gov/display/PD/Generate+-+Cloud+-+Workflow+Modifications#GenerateCloudWorkflowModifications-ModifytheLicenseReturnertohandleconcurrency)

### Overview of work done

Delivery Memo: <https://wiki.jpl.nasa.gov/display/PD/Cloud-Generate+v+0.1.1+Delivery+Memo>
ORR: <https://docs.google.com/presentation/d/1khB7ix7kHYdRMRxna61NFmqBAe7cM1zcxLVhw9OjF4M/edit?usp=sharing>

### Overview of verification done

#### Tested in SIT

Test Run Report: <https://cae-testrail.jpl.nasa.gov/testrail/index.php?/runs/view/39705&group_by=cases:title&group_order=asc>

Concurrent Execution Report: <https://cae-testrail.jpl.nasa.gov/testrail/index.php?/runs/view/40689&group_by=cases:section_id&group_order=asc>

#### Tested in UAT

UAT Test Results: <https://wiki.jpl.nasa.gov/display/PD/Generate+-+Cloud+-+UAT+Test+v0.1.1+Results>
