### PR TITLE
Release/0.1.2

### DIFF
--- a/license_returner/return_license.py
+++ b/license_returner/return_license.py
@@ -89,7 +89,7 @@ def print_final_log(logger, execution_data, idl_license_dict):
     """Print final log message."""
     
     # Organize file data into a string
-    final_log_message = execution_data
+    final_log_message = f"final_log: {execution_data}"
     for key,value in idl_license_dict.items():
         final_log_message += f" - {key}: {value}"
     


### PR DESCRIPTION
### Description

Cloud-Generate version 0.1.2.

**Scope:**

Fix final log statement to support cloud metrics pipeline AND modify to handle "TooManyUpdates" error for concurrent access to the SSM Parameter Store.

### Overview of work done

Documentation: 

- https://wiki.jpl.nasa.gov/display/PD/Generate+-+Cloud+-+CloudWatch+Logs#GenerateCloudCloudWatchLogs-CloudWatchLogs-Modifytoadd%22final_log:%22  
- https://wiki.jpl.nasa.gov/display/PD/Generate+-+Cloud+-+Workflow+Modifications#GenerateCloudWorkflowModifications-Modifythelicensereturnertocatch%22TooManyUpdates%22error

### Overview of verification done

SIT & UAT Test Results: 
- https://wiki.jpl.nasa.gov/display/PD/Generate+-+Cloud+-+CloudWatch+Logs#GenerateCloudCloudWatchLogs-CloudWatchLogs-Modifytoadd%22final_log:%22 
- https://wiki.jpl.nasa.gov/display/PD/Generate+-+Cloud+-+Workflow+Modifications#GenerateCloudWorkflowModifications-Modifythelicensereturnertocatch%22TooManyUpdates%22error