### PR TITLE
Release/0.1.7

### DIFF
--- a/license_returner/return_license.py
+++ b/license_returner/return_license.py
@@ -36,6 +36,8 @@ def run_license_returner():
         ds = "MODIS Aqua"
     elif dataset == "terra":
         ds = "MODIS Terra"
+    elif dataset == "jpss1":
+        ds = "JPSS1"
     else:
         ds = "VIIRS"
     logger.info(f"Job identifier: {os.environ.get('AWS_BATCH_JOB_ID')}")

--- a/terraform/generate-license-returner.tf
+++ b/terraform/generate-license-returner.tf
@@ -12,13 +12,14 @@ resource "aws_batch_job_definition" "generate_batch_jd_uploader" {
         }
     },
     "resourceRequirements" : [
-        { "type": "MEMORY", "value": "256"},
+        { "type": "MEMORY", "value": "2048"},
         { "type": "VCPU", "value": "1" }
     ],
-    "jobRoleArn": "${aws_iam_role.aws_batch_job_role_license_returner.arn}"
+    "jobRoleArn": "${aws_iam_role.aws_batch_job_role_license_returner.arn}",
+    "executionRoleArn": "${data.aws_iam_role.batch_ecs_execution_role.arn}"
   }
   CONTAINER_PROPERTIES
-  platform_capabilities = ["EC2"]
+  platform_capabilities = ["FARGATE"]
   propagate_tags        = true
   retry_strategy {
     attempts = 3

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -32,6 +32,10 @@ data "aws_ecr_repository" "license_returner" {
   name = "${var.prefix}-license-returner"
 }
 
+data "aws_iam_role" "batch_ecs_execution_role" {
+  name = "${var.prefix}-batch-ecs-execution-role"
+}
+
 # Local variables
 locals {
   account_id = data.aws_caller_identity.current.account_id

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "app_version" {
   type        = string
   description = "The application version number"
-  default     = "0.1.3"
+  default     = "0.1.7"
 }
 
 variable "aws_region" {


### PR DESCRIPTION
## [0.1.7]

### Description

We are migrating the managed EC2 AWS Batch Compute Environments to Fargate to prevent the need for AMI updates and to hopefully resolve the issue we are seeing with the ECS agent on EC2 instances.

Issues:

- https://github.com/podaac/generate/issues/25
- https://jira.jpl.nasa.gov/browse/PODAAC-6941

Documentation on issue:

- https://wiki.jpl.nasa.gov/pages/viewpage.action?pageId=826914206#GenerateCloudFailures&Recovery-2025-07-05-2025-07-07P&Sfailures


### Overview of work done

- Generate: Adds Fargate compute resources for batch jobs
- Generate: Removes lifeycle 'create_before_destroy' for EC2 compute resources since this policy was preventing terraform from applying the changes
- P&S: Added source hash in terraform file so it can detect changes to the job config json file
- P&S: Set retires to 0 so it only runs once
- Downloader, Combiner, Processor, Uploader, License Returner: Updated job definition/resources for Fargate instead of EC2
- Error Handler: Update EventBridge rule to ignore P&S failures.


### Overview of verification done

- Tested in SIT on three OBPG L2 granules for MODIS Aqua to produce two L2P granules

### Overview of integration done

- Tested in UAT on 7/16/2025 - 7/17/2025 time range
- Analysis of results is located here: https://wiki.jpl.nasa.gov/display/PD/Generate+-+Cloud+-+UAT+Test+v0.1.7#GenerateCloudUATTestv0.1.7-RESULTS

### Test Summary

UAT JOB METRICS:

- Total Cost: ~$157.26
- Average Execution Time: 9.65 minutes
- Average Number of Granules: 33

OPS JOB METRICS:

- Total Cost: ~$237.41 (May include other services)
- Average Execution Time: 8.8 minutes
- Average Number of Granules: 37

NOTES:

- The main difference we saw between UAT and OPS is OPS is operating in a degraded state which requires occasional manual intervention. UAT seems to have produce the usual amount of files without errors and therefore producing more granules that OPS. 
- We did see a difference in the number and average execution time of granules between UAT and OPS. This could be due to the Fargate platform which has typically had slightly longer execution times than EC2. Despite this, it seems that Generate will execute hourly on Fargate and still produce the same number of granules.